### PR TITLE
Fix confusing class name in the type exceptions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 /vendor/
 /composer.lock
 /build
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 /composer.lock
 /build
+.idea

--- a/src/Transformation/TransformationTransformerTrait.php
+++ b/src/Transformation/TransformationTransformerTrait.php
@@ -13,27 +13,28 @@ trait TransformationTransformerTrait {
     if (!isset($context)) {
       $context = new Context();
     }
-    if (!$this->conformsToExpectedInputShape($data, $context)) {
+
+    // Error utility.
+    $throwError = function($message, $arguments = []) {
       /** @var \Shaper\Validator\ValidateableInterface $validator */
       $validator = $this->getInputValidator();
-      $message = sprintf(
-        'Adaptor %s received invalid input data: %s',
-        __CLASS__,
-        json_encode($validator->getErrors(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT)
-      );
-      throw new \TypeError($message);
+      $jsonEncodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+
+      throw new \TypeError(strtr($message, $arguments + [
+        '{class}' => static::class,
+        '{data}' => json_encode($validator->getErrors(), $jsonEncodeOptions)
+      ]));
+    };
+
+    if (!$this->conformsToExpectedInputShape($data, $context)) {
+      $throwError('Adaptor {class} received invalid input data: {data}.');
     }
+
     $output = $this->doTransform($data, $context);
     if (!$this->conformsToOutputShape($output, $context)) {
-      /** @var \Shaper\Validator\ValidateableInterface $validator */
-      $validator = $this->getOutputValidator();
-      $message = sprintf(
-        'Adaptor %s returned invalid output data: %s',
-        __CLASS__,
-        json_encode($validator->getErrors(), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT)
-      );
-      throw new \TypeError($message);
+      $throwError('Adaptor {class} returned invalid output data: {data}');
     }
+
     return $output;
   }
 

--- a/src/Transformation/TransformationTransformerTrait.php
+++ b/src/Transformation/TransformationTransformerTrait.php
@@ -15,24 +15,24 @@ trait TransformationTransformerTrait {
     }
 
     // Error utility.
-    $throwError = function($message, $arguments = []) {
+    $throw = function($message, $arguments = []) {
       /** @var \Shaper\Validator\ValidateableInterface $validator */
       $validator = $this->getInputValidator();
-      $jsonEncodeOptions = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
+      $options = JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT;
 
       throw new \TypeError(strtr($message, $arguments + [
         '{class}' => static::class,
-        '{data}' => json_encode($validator->getErrors(), $jsonEncodeOptions)
+        '{data}' => json_encode($validator->getErrors(), $options)
       ]));
     };
 
     if (!$this->conformsToExpectedInputShape($data, $context)) {
-      $throwError('Adaptor {class} received invalid input data: {data}.');
+      $throw('Adaptor {class} received invalid input data: {data}.');
     }
 
     $output = $this->doTransform($data, $context);
     if (!$this->conformsToOutputShape($output, $context)) {
-      $throwError('Adaptor {class} returned invalid output data: {data}');
+      $throw('Adaptor {class} returned invalid output data: {data}');
     }
 
     return $output;


### PR DESCRIPTION
Aims at resolving this: https://github.com/e0ipso/shaper/issues/9
- Unified errors code generation.
- Using late static binding for the classes shown in the message, so we see actual adapter and not the strange base class.