### PR TITLE
fix php 8.4 deprecations

### DIFF
--- a/src/DataAdaptor/DataAdaptorTransformerTrait.php
+++ b/src/DataAdaptor/DataAdaptorTransformerTrait.php
@@ -9,7 +9,7 @@ trait DataAdaptorTransformerTrait {
   /**
    * {@inheritdoc}
    */
-  public function transform($data, Context $context = NULL) {
+  public function transform($data, ?Context $context = NULL) {
     if (!isset($context)) {
       $context = new Context();
     }
@@ -40,7 +40,7 @@ trait DataAdaptorTransformerTrait {
   /**
    * {@inheritdoc}
    */
-  public function undoTransform($data, Context $context = NULL) {
+  public function undoTransform($data, ?Context $context = NULL) {
     if (!isset($context)) {
       $context = new Context();
     }

--- a/src/DataAdaptor/DataAdaptorValidatorTrait.php
+++ b/src/DataAdaptor/DataAdaptorValidatorTrait.php
@@ -12,7 +12,7 @@ trait DataAdaptorValidatorTrait {
   /**
    * {@inheritdoc}
    */
-  public function conformsToInternalShape($data, Context $context = NULL) {
+  public function conformsToInternalShape($data, ?Context $context = NULL) {
     return $this->getInternalValidator()->isValid($data);
   }
 

--- a/src/DataAdaptor/ReversibleTransformationInterface.php
+++ b/src/DataAdaptor/ReversibleTransformationInterface.php
@@ -23,6 +23,6 @@ interface ReversibleTransformationInterface {
    * @throws \TypeError
    *   When the transformation cannot be applied.
    */
-  public function undoTransform($data, Context $context = NULL);
+  public function undoTransform($data, ?Context $context = NULL);
 
 }

--- a/src/DataAdaptor/ReversibleTransformationValidationInterface.php
+++ b/src/DataAdaptor/ReversibleTransformationValidationInterface.php
@@ -18,7 +18,7 @@ interface ReversibleTransformationValidationInterface extends TransformationVali
    * @return bool
    *   TRUE if the format is valid.
    */
-  public function conformsToInternalShape($data, Context $context = NULL);
+  public function conformsToInternalShape($data, ?Context $context = NULL);
 
   /**
    * The validator for the internal data.

--- a/src/Transformation/TransformationInterface.php
+++ b/src/Transformation/TransformationInterface.php
@@ -28,6 +28,6 @@ interface TransformationInterface {
    * @throws \TypeError
    *   When the transformation cannot be applied.
    */
-  public function transform($data, Context $context = NULL);
+  public function transform($data, ?Context $context = NULL);
 
 }

--- a/src/Transformation/TransformationTransformerTrait.php
+++ b/src/Transformation/TransformationTransformerTrait.php
@@ -9,7 +9,7 @@ trait TransformationTransformerTrait {
   /**
    * {@inheritdoc}
    */
-  public function transform($data, Context $context = NULL) {
+  public function transform($data, ?Context $context = NULL) {
     if (!isset($context)) {
       $context = new Context();
     }

--- a/src/Transformation/TransformationValidationInterface.php
+++ b/src/Transformation/TransformationValidationInterface.php
@@ -17,7 +17,7 @@ interface TransformationValidationInterface {
    * @return bool
    *   TRUE if the transformation can be used with the supplied data.
    */
-  public function conformsToExpectedInputShape($data, Context $context = NULL);
+  public function conformsToExpectedInputShape($data, ?Context $context = NULL);
 
   /**
    * Checks if the transformed data conforms to the expected shape.
@@ -30,7 +30,7 @@ interface TransformationValidationInterface {
    * @return bool
    *   TRUE if the transformed data conforms to the expected shape.
    */
-  public function conformsToOutputShape($data, Context $context = NULL);
+  public function conformsToOutputShape($data, ?Context $context = NULL);
 
   /**
    * The validator for the input data.

--- a/src/Transformation/TransformationValidationTrait.php
+++ b/src/Transformation/TransformationValidationTrait.php
@@ -9,14 +9,14 @@ trait TransformationValidationTrait {
   /**
    * {@inheritdoc}
    */
-  public function conformsToExpectedInputShape($data, Context $context = NULL) {
+  public function conformsToExpectedInputShape($data, ?Context $context = NULL) {
     return $this->getInputValidator()->isValid($data);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function conformsToOutputShape($data, Context $context = NULL) {
+  public function conformsToOutputShape($data, ?Context $context = NULL) {
     return $this->getOutputValidator()->isValid($data);
   }
 

--- a/src/Transformation/TransformationsQueue.php
+++ b/src/Transformation/TransformationsQueue.php
@@ -11,7 +11,7 @@ class TransformationsQueue extends \SplQueue implements TransformationInterface,
   /**
    * {@inheritdoc}
    */
-  public function transform($data, Context $context = NULL) {
+  public function transform($data, ?Context $context = NULL) {
     if (!isset($context)) {
       $context = new Context();
     }

--- a/src/Validator/JsonSchemaValidator.php
+++ b/src/Validator/JsonSchemaValidator.php
@@ -35,7 +35,7 @@ class JsonSchemaValidator extends ValidateableBase {
    * @param \JsonSchema\Validator $validator
    *   The validator.
    */
-  public function __construct(array $schema = NULL, Validator $validator = NULL, $mode = NULL) {
+  public function __construct(?array $schema = NULL, ?Validator $validator = NULL, $mode = NULL) {
     $this->schema = $schema;
     $this->validator = $validator;
     $this->checkMode = $mode;

--- a/tests/src/DataAdaptor/DataAdaptorFake2.php
+++ b/tests/src/DataAdaptor/DataAdaptorFake2.php
@@ -7,7 +7,7 @@ use Shaper\Util\Context;
 use Shaper\Validator\AcceptValidator;
 
 class DataAdaptorFake2 extends DataAdaptorFake {
-  public function conformsToExpectedInputShape($data, Context $context = NULL) {
+  public function conformsToExpectedInputShape($data, ?Context $context = NULL) {
     return FALSE;
   }
 }

--- a/tests/src/DataAdaptor/DataAdaptorFake3.php
+++ b/tests/src/DataAdaptor/DataAdaptorFake3.php
@@ -7,7 +7,7 @@ use Shaper\Util\Context;
 use Shaper\Validator\AcceptValidator;
 
 class DataAdaptorFake3 extends DataAdaptorFake {
-  public function conformsToInternalShape($data, Context $context = NULL) {
+  public function conformsToInternalShape($data, ?Context $context = NULL) {
     return FALSE;
   }
 }

--- a/tests/src/DataAdaptor/DataAdaptorFake4.php
+++ b/tests/src/DataAdaptor/DataAdaptorFake4.php
@@ -7,7 +7,7 @@ use Shaper\Util\Context;
 use Shaper\Validator\AcceptValidator;
 
 class DataAdaptorFake4 extends DataAdaptorFake {
-  public function conformsToOutputShape($data, Context $context = NULL) {
+  public function conformsToOutputShape($data, ?Context $context = NULL) {
     return FALSE;
   }
 }


### PR DESCRIPTION
PHP 8.4 warns that passing an implicit null is deprecated.

Fixed with:

```
  $rectorConfig->rule(\Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector::class);
```